### PR TITLE
Update zenn-cli to version 0.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 .DS_Store
 .idea
+
+.claude/*local.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,50 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Zenn content repository for managing technical articles and books. Zenn is a Japanese platform for developers to publish technical content. The repository uses `zenn-cli` for content management and preview.
+
+## Architecture & Structure
+
+- `articles/` - Contains individual technical articles in Markdown format with YAML frontmatter
+- `books/` - Directory for book-length content (currently empty)
+- Package manager: npm (uses package-lock.json, not pnpm despite references in old docs)
+- Single dependency: `zenn-cli` for content management
+
+## Content Format
+
+Articles follow Zenn's frontmatter format:
+```yaml
+---
+title: "Article Title"
+emoji: "😘"
+type: "tech" # tech: 技術記事 / idea: アイデア  
+topics: ["flutter", "firebase"]
+published: true
+---
+```
+
+## Common Commands
+
+**Important**: This project uses npm, not pnpm. Correct commands:
+
+### Development
+- `npx zenn preview` - Start local preview server to view content in browser
+- `npx zenn new:article` - Create a new article
+- `npx zenn new:book` - Create a new book
+- `npm install` - Install dependencies
+
+### Content Management
+- Articles are written in Markdown with Zenn-specific extensions
+- Images are hosted on Zenn's CDN or external services (e.g., `https://storage.googleapis.com/zenn-user-upload/`)
+- Content supports code blocks, embeds, and special Zenn syntax
+- Content is primarily in Japanese
+
+## Development Notes
+
+- No build/test process - content is deployed directly to Zenn platform
+- Topics focus on Flutter, Firebase, WebStorm, automation tools, and mobile development
+- Articles include practical tutorials with code examples and GIFs/images
+- Preview changes locally before publishing using `npx zenn preview`

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,16 +5,17 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "zenn-content",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "zenn-cli": "^0.1.158"
+        "zenn-cli": "^0.2.1"
       }
     },
     "node_modules/zenn-cli": {
-      "version": "0.1.158",
-      "resolved": "https://registry.npmjs.org/zenn-cli/-/zenn-cli-0.1.158.tgz",
-      "integrity": "sha512-bvQ96fK+9qw+SKxEmncg/rYU+1u0V6Bh+HuV8By+u4L+VZt/jn9hFyL+KWj/2ncSBDtcEBo6XLsCdNLxlUo+RA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/zenn-cli/-/zenn-cli-0.2.1.tgz",
+      "integrity": "sha512-8ipbiIHOGIK1Gp1ifNi4rKY3+YohcXCrQCuz6w78OQ532WoU2xMiV0hFWRR/obmuPYwbiGWd/Xt/A4tYCaOHTA==",
       "license": "MIT",
       "bin": {
         "zenn": "dist/server/zenn.js"
@@ -26,9 +27,9 @@
   },
   "dependencies": {
     "zenn-cli": {
-      "version": "0.1.158",
-      "resolved": "https://registry.npmjs.org/zenn-cli/-/zenn-cli-0.1.158.tgz",
-      "integrity": "sha512-bvQ96fK+9qw+SKxEmncg/rYU+1u0V6Bh+HuV8By+u4L+VZt/jn9hFyL+KWj/2ncSBDtcEBo6XLsCdNLxlUo+RA=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/zenn-cli/-/zenn-cli-0.2.1.tgz",
+      "integrity": "sha512-8ipbiIHOGIK1Gp1ifNi4rKY3+YohcXCrQCuz6w78OQ532WoU2xMiV0hFWRR/obmuPYwbiGWd/Xt/A4tYCaOHTA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   "homepage": "https://github.com/harunonsystem/zenn-content#readme",
   "description": "",
   "dependencies": {
-    "zenn-cli": "^0.1.158"
+    "zenn-cli": "^0.2.1"
   }
 }


### PR DESCRIPTION
## Summary
- Updated zenn-cli from version 0.1.158 to 0.2.1
- Updated package.json and package-lock.json accordingly
- Ensures we have the latest features and bug fixes from zenn-cli

## Test plan
- [x] Verified installation completed successfully with no vulnerabilities
- [ ] Test local preview with `npx zenn preview`
- [ ] Verify content rendering works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)